### PR TITLE
Add post and feed as livequery classes

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -39,7 +39,7 @@ const api = new ParseServer({
   },
   liveQuery: {
     // List of classes to support for query subscriptions
-    classNames: ['QuePositions'],
+    classNames: ['QuePositions', 'Post', 'Feed'],
     redisUrl: REDIS_URL,
   },
   protectedFields: {


### PR DESCRIPTION
This PR enable post and feed classes as LiveQuery classes.
Closes #183 