### PR TITLE
Create posts for unread messages logic

### DIFF
--- a/src/chatEventWebhooks/chatAfterEvent/onMemberAdded.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMemberAdded.js
@@ -11,6 +11,8 @@ class OnMemberRemovedAdded extends ExtendableError {}
  *
  * @param {*} user
  * @param {*} channel
+ *
+ * @returns {object} twilio message
  */
 const createUserJoinedMessage = async (user, channel) => {
   // Create message structure

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
@@ -33,9 +33,6 @@ const onMessageSent = async (request, response) => {
     const users = usersIdentities.map(uid => Parse.User.createWithoutData(uid));
 
     if (users.length) {
-      // Post for unread messages
-      // If already exists a post for the given channel, retrieve it.
-      // If not, create it.
       const fromUser = await new Parse.Query(Parse.User).get(From);
       if (context === 'emergency') {
         const data = {
@@ -54,14 +51,8 @@ const onMessageSent = async (request, response) => {
       }
 
       // Increase by 1 the unread messages in all the needed posts
-      await FeedService.updatePostUnreadMessages(
-        INCREASE_UNREAD_MESSAGES,
-        ChannelSid,
-      );
-      await FeedService.updateGeneralPostUnreadMessage(
-        INCREASE_UNREAD_MESSAGES,
-        ChannelSid,
-      );
+      await FeedService.increasePostUnreadMessages(ChannelSid);
+      await FeedService.increaseGeneralPostUnreadMessage(ChannelSid);
     }
 
     return response.status(200).json(pushStatus);

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
@@ -1,7 +1,7 @@
 import Parse from '../../providers/ParseProvider';
 import PushService from '../../services/PushService';
 import ChatService from '../../services/ChatService';
-import { NOTIFICATION_TYPES, INCREASE_UNREAD_MESSAGES } from '../../constants';
+import { NOTIFICATION_TYPES } from '../../constants';
 import FeedService from '../../services/FeedService';
 
 /**

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
@@ -1,7 +1,8 @@
 import Parse from '../../providers/ParseProvider';
-import Twilio from '../../providers/TwilioProvider';
 import PushService from '../../services/PushService';
-import { NOTIFICATION_TYPES } from '../../constants';
+import ChatService from '../../services/ChatService';
+import { NOTIFICATION_TYPES, INCREASE_UNREAD_MESSAGES } from '../../constants';
+import FeedService from '../../services/FeedService';
 
 /**
  * EventType - string - Always onMessageSent
@@ -24,22 +25,19 @@ const onMessageSent = async (request, response) => {
     if (!Attributes) throw new Error('No Attributes present on the resquest.');
     const { context } = JSON.parse(Attributes);
 
-    if (context === 'emergency') {
-      const membersList = await new Twilio().client.chat
-        .services(process.env.TWILIO_SERVICE_SID)
-        .channels(ChannelSid)
-        .members.list();
+    const membersList = await ChatService.getChannelMembers(ChannelSid);
 
-      const usersIdentities = membersList
-        .map(m => m.identity)
-        .filter(u => u !== From);
-      const users = usersIdentities.map(uid =>
-        Parse.User.createWithoutData(uid),
-      );
+    const usersIdentities = membersList
+      .map(m => m.identity)
+      .filter(u => u !== From);
+    const users = usersIdentities.map(uid => Parse.User.createWithoutData(uid));
 
+    if (users.length) {
+      // Post for unread messages
+      // If already exists a post for the given channel, retrieve it.
+      // If not, create it.
       const fromUser = await new Parse.Query(Parse.User).get(From);
-
-      if (users.length) {
+      if (context === 'emergency') {
         const data = {
           messageId: MessageSid,
           channelId: ChannelSid,
@@ -54,6 +52,16 @@ const onMessageSent = async (request, response) => {
           users,
         );
       }
+
+      // Increase by 1 the unread messages in all the needed posts
+      await FeedService.updatePostUnreadMessages(
+        INCREASE_UNREAD_MESSAGES,
+        ChannelSid,
+      );
+      await FeedService.updateGeneralPostUnreadMessage(
+        INCREASE_UNREAD_MESSAGES,
+        ChannelSid,
+      );
     }
 
     return response.status(200).json(pushStatus);

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
@@ -1,7 +1,7 @@
 import Parse from '../../providers/ParseProvider';
 import PushService from '../../services/PushService';
 import FeedService from '../../services/FeedService';
-import { NOTIFICATION_TYPES, DECREASE_UNREAD_MESSAGES } from '../../constants';
+import { NOTIFICATION_TYPES } from '../../constants';
 
 /**
  * EventType - string - Always onMessageUpdated

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
@@ -1,6 +1,7 @@
 import Parse from '../../providers/ParseProvider';
 import PushService from '../../services/PushService';
-import { NOTIFICATION_TYPES } from '../../constants';
+import FeedService from '../../services/FeedService';
+import { NOTIFICATION_TYPES, DECREASE_UNREAD_MESSAGES } from '../../constants';
 
 /**
  * EventType - string - Always onMessageUpdated
@@ -31,15 +32,20 @@ const onMessageUpdated = async (request, response) => {
 
     if (!Attributes) throw new Error('No Attributes present on the resquest.');
 
+    // FIXME: Consumers do not exist anymore?
     const { consumers = [], context = '' } = JSON.parse(Attributes);
-    if (consumers.includes(ModifiedBy) && context === 'emergency') {
-      const [author, reader] = await Promise.all([
-        new Parse.Query(Parse.User).get(From, { useMasterKey: true }),
-        new Parse.Query(Parse.User).get(ModifiedBy, {
-          useMasterKey: true,
-        }),
-      ]);
 
+    // Get the Parse.User for author and reader
+    const [author, reader] = await Promise.all([
+      new Parse.Query(Parse.User).get(From, { useMasterKey: true }),
+      new Parse.Query(Parse.User).get(ModifiedBy, {
+        useMasterKey: true,
+      }),
+    ]);
+
+    // If the messages has emergency context,
+    // send a push notification that is has been read
+    if (consumers.includes(ModifiedBy) && context === 'emergency') {
       const body = `${reader.get('handle')} read your message`;
       const data = {
         messageId: MessageSid,
@@ -55,6 +61,17 @@ const onMessageUpdated = async (request, response) => {
         [author],
       );
     }
+
+    // Decrease by 1 the unread messages in all the needed posts
+    await FeedService.updatePostUnreadMessages(
+      DECREASE_UNREAD_MESSAGES,
+      ChannelSid,
+    );
+    await FeedService.updateGeneralPostUnreadMessage(
+      DECREASE_UNREAD_MESSAGES,
+      ChannelSid,
+    );
+
     return response.status(200).json(pushStatus);
   } catch (error) {
     return response.status(500).json({ error: error.message });

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
@@ -35,7 +35,7 @@ const onMessageUpdated = async (request, response) => {
     // FIXME: Consumers do not exist anymore?
     const { consumers = [], context = '' } = JSON.parse(Attributes);
 
-    // Get the Parse.User for author and reader
+    // Get the Parse.Users for author and reader
     const [author, reader] = await Promise.all([
       new Parse.Query(Parse.User).get(From, { useMasterKey: true }),
       new Parse.Query(Parse.User).get(ModifiedBy, {
@@ -44,7 +44,7 @@ const onMessageUpdated = async (request, response) => {
     ]);
 
     // If the messages has emergency context,
-    // send a push notification that is has been read
+    // send a push notification that it has been read
     if (consumers.includes(ModifiedBy) && context === 'emergency') {
       const body = `${reader.get('handle')} read your message`;
       const data = {
@@ -63,14 +63,8 @@ const onMessageUpdated = async (request, response) => {
     }
 
     // Decrease by 1 the unread messages in all the needed posts
-    await FeedService.updatePostUnreadMessages(
-      DECREASE_UNREAD_MESSAGES,
-      ChannelSid,
-    );
-    await FeedService.updateGeneralPostUnreadMessage(
-      DECREASE_UNREAD_MESSAGES,
-      ChannelSid,
-    );
+    await FeedService.decreasePostUnreadMessages(reader, ChannelSid);
+    await FeedService.decreaseGeneralPostUnreadMessage(reader, ChannelSid);
 
     return response.status(200).json(pushStatus);
   } catch (error) {

--- a/src/cloud/sendCode.js
+++ b/src/cloud/sendCode.js
@@ -3,6 +3,7 @@ import ExtendableError from 'extendable-error-class';
 import { PhoneNumberUtil, PhoneNumberFormat } from 'google-libphonenumber';
 // Providers
 import Parse from '../providers/ParseProvider';
+import FeedService from '../services/FeedService';
 // Services
 import TwoFAService, { TwoFAServiceError } from '../services/TwoFAService';
 import UserService from '../services/UserService';
@@ -75,7 +76,8 @@ const sendCode = async request => {
     user.set('smsVerificationStatus', status);
     await user.save(null, { useMasterKey: true });
     await UserService.asignDefaultRole(user);
-    await UserService.createUserFeed(user);
+    await FeedService.createFeedForUser(user);
+    await FeedService.createGeneralUnreadMessagesPost(user);
 
     return { status: 'code sent' };
   } catch (error) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,10 @@
+export const UNREADMESSAGES_POST_TYPE = 'unreadMessagesPost';
+export const GENERAL_UNREADMESSAGES_POST_TYPE = 'generalUnreadMessagesPost';
+export const INCREASE_UNREAD_MESSAGES = 'INCREASE_UNREAD_MESSAGES';
+export const DECREASE_UNREAD_MESSAGES = 'DECREASE_UNREAD_MESSAGES';
+
+export const ONBOARD_ADMIN = 'ONBOARD_ADMIN';
+
 export const STATUS_INVITED = 'invited';
 export const STATUS_ACCEPTED = 'accepted';
 export const STATUS_DECLINED = 'declined';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,7 +1,5 @@
 export const UNREADMESSAGES_POST_TYPE = 'unreadMessagesPost';
 export const GENERAL_UNREADMESSAGES_POST_TYPE = 'generalUnreadMessagesPost';
-export const INCREASE_UNREAD_MESSAGES = 'INCREASE_UNREAD_MESSAGES';
-export const DECREASE_UNREAD_MESSAGES = 'DECREASE_UNREAD_MESSAGES';
 
 export const ONBOARD_ADMIN = 'ONBOARD_ADMIN';
 

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -88,6 +88,8 @@ const addMembersToChannel = async (channelSid, members = []) =>
  * Returns the members of the given channel
  *
  * @param {*} ChannelSid
+ *
+ * @returns {Array<String>} membersList
  */
 const getChannelMembers = async ChannelSid => {
   try {

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -85,6 +85,23 @@ const addMembersToChannel = async (channelSid, members = []) =>
   );
 
 /**
+ * Returns the members of the given channel
+ *
+ * @param {*} ChannelSid
+ */
+const getChannelMembers = async ChannelSid => {
+  try {
+    const membersList = await new Twilio().client.chat
+      .services(process.env.TWILIO_SERVICE_SID)
+      .channels(ChannelSid)
+      .members.list();
+    return membersList;
+  } catch (error) {
+    throw new ChatServiceError(error.message);
+  }
+};
+
+/**
  * Get all user channels
  *
  * @param {String} userId
@@ -191,6 +208,7 @@ export default {
   createChatChannel,
   inviteMembers,
   addMembersToChannel,
+  getChannelMembers,
   deleteTwilioUser,
   deleteUserChannels,
   createMessage,

--- a/src/services/FeedService.js
+++ b/src/services/FeedService.js
@@ -1,22 +1,234 @@
-// Providers
 // Vendor
 import ExtendableError from 'extendable-error-class';
+// Providers
 import Parse from '../providers/ParseProvider';
+// Constants
+import {
+  UNREADMESSAGES_POST_TYPE,
+  GENERAL_UNREADMESSAGES_POST_TYPE,
+  INCREASE_UNREAD_MESSAGES,
+  DECREASE_UNREAD_MESSAGES,
+} from '../constants/index';
+// Utils
+import db from '../utils/db';
 
 class FeedServiceError extends ExtendableError {}
 
-const createFeedForUser = user => {
+/**
+ * Creates the feed object for the given user
+ */
+const createFeedForUser = async user => {
   try {
-    const feed = new Parse.Object('Feed');
-    feed.setACL(new Parse.ACL(user));
-    feed.set('user', user);
-    feed.save(null, { userMasterKey: true });
+    let feed = await new Parse.Query('Feed').equalTo('user', user).first();
+    if (!feed) {
+      feed = new Parse.Object('Feed');
+      feed.setACL(new Parse.ACL(user));
+      feed.set('user', user);
+      feed.save(null, { userMasterKey: true });
+    }
     return feed;
   } catch (error) {
     throw new FeedServiceError(error.message);
   }
 };
 
+/**
+ * Creates a post with the given data
+ *
+ * @param {*} data
+ */
+const createPost = data => {
+  const {
+    type,
+    priority,
+    body,
+    expirationDate = null,
+    triggerDate = null,
+    subject,
+    author,
+    attributes,
+  } = data;
+  try {
+    const post = new Parse.Object('Post');
+    post.set('type', type);
+    post.set('priority', priority);
+    post.set('body', body);
+    post.set('expirationDate', expirationDate);
+    post.set('triggerDate', triggerDate);
+    post.set('subject', subject);
+    post.set('author', author);
+    post.set('attributes', attributes);
+    post.save(null, { userMasterKey: true });
+    return post;
+  } catch (error) {
+    throw new FeedServiceError(error.message);
+  }
+};
+
+/**
+ * Creates the post for the unread messages for the recently added member
+ *
+ * @param {*} user
+ * @param {*} channel
+ */
+const createUnreadMessagesPost = async (user, channel) => {
+  try {
+    // Check if the post already exists
+    let unreadMessagesPost = await new Parse.Query('Post')
+      .equalTo('type', 'unreadMessages')
+      .equalTo('attributes.channelSid', channel.sid)
+      .equalTo('author', user)
+      .first();
+    if (!unreadMessagesPost) {
+      // Create the post structure
+      const postData = {
+        type: 'unreadMessages',
+        priority: 1,
+        body: `You have (0) unread message/s in the conversation: (${channel.friendlyName}).`,
+        expirationDate: null,
+        triggerDate: null,
+        subject: '',
+        author: user,
+        attributes: {
+          numberOfUnread: 0,
+          channelSid: channel.sid,
+        },
+      };
+      // Create the post
+      unreadMessagesPost = await createPost(postData);
+    }
+    return unreadMessagesPost;
+  } catch (error) {
+    throw new FeedServiceError(error.message);
+  }
+};
+
+/**
+ * Creates a post to be user for the general unread messages info
+ *
+ * @param {*} user
+ */
+const createGeneralUnreadMessagesPost = async user => {
+  try {
+    // Check if the post already exists
+    let generalUnreadMessagesPost = await new Parse.Query('Post')
+      .equalTo('type', GENERAL_UNREADMESSAGES_POST_TYPE)
+      .equalTo('author', user)
+      .first();
+    // If no general post, create one
+    if (!generalUnreadMessagesPost) {
+      // Create the post structure
+      const postData = {
+        type: 'generalUnreadMessages',
+        priority: 1,
+        body: `You have (0) unread message/s.`,
+        expirationDate: null,
+        triggerDate: null,
+        subject: '',
+        author: user,
+        attributes: {
+          numberOfUnread: 0,
+        },
+      };
+      generalUnreadMessagesPost = await createPost(postData);
+    }
+    return generalUnreadMessagesPost;
+  } catch (error) {
+    throw new FeedServiceError(error.message);
+  }
+};
+
+/**
+ * Retrieves all the post with type = UNREADMESSAGES_POST_TYPE
+ * and updates the unreadMessages attribute (increase or decrease)
+ *
+ * @param {*} type
+ * @param {*} channelsid
+ */
+const updatePostUnreadMessages = async (type, channelsid) => {
+  // Get all unreadMessages posts for the channel
+  const unreadMessagesPosts = await new Parse.Query('Post')
+    .equalTo('type', UNREADMESSAGES_POST_TYPE)
+    .equalTo('attributes.channelSid', channelsid)
+    .first();
+  // Update (increase/decrese) by 1 the unreadMessages counter
+  if (unreadMessagesPosts.length) {
+    unreadMessagesPosts.forEach(urmp => {
+      if (type === INCREASE_UNREAD_MESSAGES) {
+        db.getValueForNextSequence(`unreadMessages_${urmp.id}`)
+          .then(numberOfUnread => {
+            urmp.set('attributes.numberOfUnread', numberOfUnread);
+            urmp.save(null, { useMasterKey: true });
+          })
+          .catch(error => {
+            throw new FeedServiceError(error.message);
+          });
+      }
+      // TODO: Decrease (needs implementation)
+      if (type === DECREASE_UNREAD_MESSAGES) {
+        db.getPreviousValueForSequence(`unreadMessages_${urmp.id}`)
+          .then(numberOfUnread => {
+            if (numberOfUnread) {
+              urmp.set('attributes.numberOfUnread', numberOfUnread);
+              urmp.save(null, { useMasterKey: true });
+            }
+          })
+          .catch(error => {
+            throw new FeedServiceError(error.message);
+          });
+      }
+    });
+  }
+};
+
+/**
+ * Retrieves all the post with type = GENERAL_UNREADMESSAGES_POST_TYPE
+ * and updates the unreadMessages attribute (increase or decrease)
+ *
+ * @param {*} type
+ * @param {*} channelsid
+ */
+const updateGeneralPostUnreadMessage = async (type, channelsid) => {
+  // Get all the generalUnreadMessages post for the channel
+  const generalUnreadMessagesPosts = await new Parse.Query('Post')
+    .equalTo('type', GENERAL_UNREADMESSAGES_POST_TYPE)
+    .equalTo('attributes.channelSid', channelsid)
+    .first();
+  // Decrement by 1 the unreadMessages counter
+  if (generalUnreadMessagesPosts.length) {
+    generalUnreadMessagesPosts.forEach(gurmp => {
+      if (type === INCREASE_UNREAD_MESSAGES) {
+        db.getValueForNextSequence(`unreadMessages_${gurmp.id}`)
+          .then(numberOfUnread => {
+            gurmp.set('attributes.numberOfUnread', numberOfUnread);
+            gurmp.save(null, { useMasterKey: true });
+          })
+          .catch(error => {
+            throw new FeedServiceError(error.message);
+          });
+      }
+      // TODO: Decrease (needs implementation)
+      if (type === DECREASE_UNREAD_MESSAGES) {
+        db.getPreviousValueForSequence(`unreadMessages_${gurmp.id}`)
+          .then(numberOfUnread => {
+            if (numberOfUnread) {
+              gurmp.set('attributes.numberOfUnread', numberOfUnread);
+              gurmp.save(null, { useMasterKey: true });
+            }
+          })
+          .catch(error => {
+            throw new FeedServiceError(error.message);
+          });
+      }
+    });
+  }
+};
+
 export default {
+  createPost,
   createFeedForUser,
+  createUnreadMessagesPost,
+  createGeneralUnreadMessagesPost,
+  updatePostUnreadMessages,
+  updateGeneralPostUnreadMessage,
 };

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -1,13 +1,11 @@
-// Providers
 // Vendor
 import hat from 'hat';
 import uuidv4 from 'uuid/v4';
 import ExtendableError from 'extendable-error-class';
+// Providers
 import Parse from '../providers/ParseProvider';
 // Utils
 import generatePassword from '../utils/generatePassword';
-// Services
-import FeedService from './FeedService';
 
 class UserServiceError extends ExtendableError {}
 
@@ -66,23 +64,6 @@ const asignDefaultRole = async user => {
       }
     }
     return user;
-  } catch (error) {
-    throw new UserServiceError(error.message);
-  }
-};
-
-/**
- * Creates the feed for the given user
- *
- * @param {*} user
- */
-const createUserFeed = async user => {
-  try {
-    const feed = await new Parse.Query('Feed').equalTo('user', user).first();
-    if (!feed) {
-      await FeedService.createFeedForUser(user);
-    }
-    return feed;
   } catch (error) {
     throw new UserServiceError(error.message);
   }
@@ -198,7 +179,6 @@ const deleteReservations = async user => {
 export default {
   createUser,
   asignDefaultRole,
-  createUserFeed,
   getLastSessionToken,
   clearUserSessions,
   deleteUserInstallations,

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -26,7 +26,7 @@ const getValueForNextSequence = async sequenceOfName => {
       { $inc: { sequence_value: 1 } },
       { upsert: true },
     );
-    return !value ? value + 1 : value.sequence_value + 1;
+    return !value ? 1 : value.sequence_value + 1;
   } catch (error) {
     throw new DbUtilError(error.message);
   }
@@ -42,15 +42,12 @@ const getPreviousValueForSequence = async sequenceOfName => {
     const db = getDatabaseInstance();
 
     const sequences = db.collection('_sequences'); // returns new instance of _sequences if collections doesn't exists.
-    let { value } = await sequences.findOneAndUpdate(
+    const { value } = await sequences.findOneAndUpdate(
       { _id: sequenceOfName },
       { $inc: { sequence_value: -1 } },
       { upsert: true },
     );
-    if (!value || value) {
-      value = 0;
-    }
-    return value;
+    return !value ? -1 : value.sequence_value - 1;
   } catch (error) {
     throw new DbUtilError(error.message);
   }

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -32,6 +32,18 @@ const getValueForNextSequence = async sequenceOfName => {
   }
 };
 
+// FIXME: Provide a better description
+// TODO: Implement logic
+/** *
+ * Decrement by 1 the value for the given sequence.
+ *
+ * @param {String} sequenceOfName
+ */
+const getPreviousValueForSequence = async sequenceOfName => {
+  const message = `Do something here with: ${sequenceOfName}`;
+  return message;
+};
+
 /**
  * Read sequence current value.
  *
@@ -53,4 +65,5 @@ export default {
   getDatabaseInstance,
   getValueForNextSequence,
   getCurrentValueSequence,
+  getPreviousValueForSequence,
 };

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -32,16 +32,28 @@ const getValueForNextSequence = async sequenceOfName => {
   }
 };
 
-// FIXME: Provide a better description
-// TODO: Implement logic
 /** *
  * Decrement by 1 the value for the given sequence.
  *
  * @param {String} sequenceOfName
  */
 const getPreviousValueForSequence = async sequenceOfName => {
-  const message = `Do something here with: ${sequenceOfName}`;
-  return message;
+  try {
+    const db = getDatabaseInstance();
+
+    const sequences = db.collection('_sequences'); // returns new instance of _sequences if collections doesn't exists.
+    let { value } = await sequences.findOneAndUpdate(
+      { _id: sequenceOfName },
+      { $inc: { sequence_value: -1 } },
+      { upsert: true },
+    );
+    if (!value || value) {
+      value = 0;
+    }
+    return value;
+  } catch (error) {
+    throw new DbUtilError(error.message);
+  }
 };
 
 /**


### PR DESCRIPTION
Closes #87

When a user is created in sendCode fn:
- Create the unread messages general post.

When a user joins a channel:
- Create a post for the unread messages for that channel

Everytime a message is sent:
- Increase by 1 the unreadMessages counter for that channel for all the users except the creator of the message
- Increase by 1 the general unreadMessages counter for all the users except the creator of the message

Everytime a message is read
- Decrease by 1 the unreadMessages counter for that user and that channel
- Decrease by 1 the unreadMessages counter for that user in the general unreadMessages post