### PR TITLE
Fixed how to count the unreadMessages post

### DIFF
--- a/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
@@ -51,9 +51,11 @@ const onMessageSent = async (request, response) => {
         );
       }
 
-      // Increase by 1 the unread messages in all the needed posts
-      await FeedService.increasePostUnreadMessages(fromUser, channel);
-      await FeedService.increaseGeneralPostUnreadMessages(users, channel);
+      // Increase by 1 the unread messages in all the needed posts if the context is not 'status'
+      if (context !== 'status') {
+        await FeedService.increasePostUnreadMessages(fromUser, channel);
+        await FeedService.increaseGeneralPostUnreadMessages(users, channel);
+      }
     }
 
     return response.status(200).json(pushStatus);

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -47,7 +47,7 @@ const getPreviousValueForSequence = async sequenceOfName => {
       { $inc: { sequence_value: -1 } },
       { upsert: true },
     );
-    return !value ? -1 : value.sequence_value - 1;
+    return !value ? 0 : value.sequence_value - 1;
   } catch (error) {
     throw new DbUtilError(error.message);
   }


### PR DESCRIPTION
- Added a verification for the context for the message. If its 'status', It won't increase the unreadMessages count.
- Default return value for the decrease sequence its 0 when no sequence is found.