### PR TITLE
Initial version for the new unreadMessagesPost logic

### DIFF
--- a/src/chatEventWebhooks/chatAfterEvent/onMemberAdded.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMemberAdded.js
@@ -64,12 +64,10 @@ const onMemberAdded = async (request, response) => {
         .first();
       // Check the role
       if (userRole && userRole.get('name') !== ONBOARDING_ADMIN) {
-        const message = await createUserJoinedMessage(user, channel.sid);
+        const message = await createUserJoinedMessage(user, ChannelSid);
         messageSid = message.sid;
       }
     }
-    // Finally, create the post for the unread messages for the user
-    await FeedService.createUnreadMessagesPost(user, channel);
 
     return response.status(200).json({ messageSid });
   } catch (error) {

--- a/src/chatEventWebhooks/chatAfterEvent/onMemberAdded.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMemberAdded.js
@@ -1,6 +1,5 @@
 import ExtendableError from 'extendable-error-class';
 import ChatService from '../../services/ChatService';
-import FeedService from '../../services/FeedService';
 import Parse from '../../providers/ParseProvider';
 import { ONBOARDING_ADMIN } from '../../constants/index';
 

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageSent.js
@@ -24,10 +24,7 @@ const onMessageSent = async (request, response) => {
   try {
     if (!Attributes) throw new Error('No Attributes present on the resquest.');
     const { context } = JSON.parse(Attributes);
-
-    const channel = await ChatService.fetchChannel(ChannelSid);
     const membersList = await ChatService.getChannelMembers(ChannelSid);
-
     const usersIdentities = membersList
       .map(m => m.identity)
       .filter(u => u !== From);
@@ -53,8 +50,7 @@ const onMessageSent = async (request, response) => {
 
       // Increase by 1 the unread messages in all the needed posts if the context is not 'status'
       if (context !== 'status') {
-        await FeedService.increasePostUnreadMessages(fromUser, channel);
-        await FeedService.increaseGeneralPostUnreadMessages(users, channel);
+        await FeedService.increasePostUnreadMessages(fromUser, ChannelSid);
       }
     }
 

--- a/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
+++ b/src/chatEventWebhooks/chatAfterEvent/onMessageUpdated.js
@@ -32,10 +32,7 @@ const onMessageUpdated = async (request, response) => {
     } = request.body;
 
     if (!Attributes) throw new Error('No Attributes present on the resquest.');
-
-    const channel = await ChatService.fetchChannel(ChannelSid);
     const { consumers = [], context = '' } = JSON.parse(Attributes);
-
     // Get the Parse.Users for author and reader
     const [author, reader] = await Promise.all([
       new Parse.Query(Parse.User).get(From, { useMasterKey: true }),
@@ -65,10 +62,8 @@ const onMessageUpdated = async (request, response) => {
         [author],
       );
     }
-
     // Decrease by 1 the unread messages in all the needed posts
-    await FeedService.decreasePostUnreadMessages(reader, channel);
-    await FeedService.decreaseGeneralPostUnreadMessages(reader, channel);
+    await FeedService.decreasePostUnreadMessages(reader, ChannelSid);
 
     return response.status(200).json(pushStatus);
   } catch (error) {

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -295,7 +295,6 @@ const createInitialChannels = async user => {
     givenName: user.get('givenName'),
   });
   await addMembersToChannel(welcomeChannel.sid, members);
-  await FeedService.createUnreadMessagesPost(user, welcomeChannel);
 
   const feedbackChannel = await createChatChannel(
     user,
@@ -307,7 +306,6 @@ const createInitialChannels = async user => {
   // Send the feedback message
   await createMessagesForChannel(feedbackChannel);
   await addMembersToChannel(feedbackChannel.sid, members);
-  await FeedService.createUnreadMessagesPost(user, feedbackChannel);
 };
 
 export default {

--- a/src/services/ChatService.js
+++ b/src/services/ChatService.js
@@ -6,7 +6,6 @@ import Twilio from '../providers/TwilioProvider';
 import MessagesUtil from '../utils/messages';
 // Constants
 import { ONBOARDING_ADMIN } from '../constants/index';
-import FeedService from './FeedService';
 
 export class ChatServiceError extends ExtendableError {}
 

--- a/src/services/FeedService.js
+++ b/src/services/FeedService.js
@@ -3,10 +3,7 @@ import ExtendableError from 'extendable-error-class';
 // Providers
 import Parse from '../providers/ParseProvider';
 // Constants
-import {
-  UNREADMESSAGES_POST_TYPE,
-  GENERAL_UNREADMESSAGES_POST_TYPE,
-} from '../constants';
+import { UNREADMESSAGES_POST_TYPE } from '../constants';
 // Utils
 import db from '../utils/db';
 
@@ -178,34 +175,29 @@ const getFeeds = async user => {
 };
 
 /**
- * Creates the post for the unread messages for the recently added member
+ * Creates a post to be user for the general unread messages info
  *
  * @param {*} user
- * @param {*} channel
  */
-const createUnreadMessagesPost = async (user, channel) => {
+const createUnreadMessagesPost = async user => {
   try {
     // Check if the post already exists
     let unreadMessagesPost = await new Parse.Query('Post')
       .equalTo('type', UNREADMESSAGES_POST_TYPE)
-      .equalTo('attributes.channelSid', channel.sid)
       .equalTo('author', user)
       .first();
+    // If no general post, create one
     if (!unreadMessagesPost) {
       // Create the post structure
       const postData = {
         type: UNREADMESSAGES_POST_TYPE,
         priority: 1,
-        body: `You have (0) unread message/s in the conversation: (${channel.FriendlyName}).`,
+        body: `Unread messages post`,
         expirationDate: null,
         triggerDate: null,
         author: user,
-        attributes: {
-          numberOfUnread: 0,
-          channelSid: channel.sid,
-        },
+        attributes: { unreads: [] },
       };
-      // Create the post
       unreadMessagesPost = await createPost(postData);
     }
     return unreadMessagesPost;
@@ -215,37 +207,36 @@ const createUnreadMessagesPost = async (user, channel) => {
 };
 
 /**
- * Creates a post to be user for the general unread messages info
+ * Updates the given unreadMessages post with the given data
  *
+ * @param {*} post
+ * @param {*} channelSid
+ * @param {*} numberOfUnreads
  * @param {*} user
  */
-const createGeneralUnreadMessagesPost = async user => {
-  try {
-    // Check if the post already exists
-    let generalUnreadMessagesPost = await new Parse.Query('Post')
-      .equalTo('type', GENERAL_UNREADMESSAGES_POST_TYPE)
-      .equalTo('author', user)
-      .first();
-    // If no general post, create one
-    if (!generalUnreadMessagesPost) {
-      // Create the post structure
-      const postData = {
-        type: GENERAL_UNREADMESSAGES_POST_TYPE,
-        priority: 0,
-        body: `You have (0) unread message/s.`,
-        expirationDate: null,
-        triggerDate: null,
-        author: user,
-        attributes: {
-          numberOfUnread: 0,
-        },
-      };
-      generalUnreadMessagesPost = await createPost(postData);
-    }
-    return generalUnreadMessagesPost;
-  } catch (error) {
-    throw new FeedServiceError(error.message);
+const updateUnreadMessagesPost = (post, channelSid, numberOfUnreads, user) => {
+  const { unreads } = post.get('attributes');
+  let updatedUnreads;
+  const unreadExists = unreads.find(unread => unread.channelSid === channelSid);
+  if (unreadExists) {
+    updatedUnreads = unreads.map(unread => {
+      const updatedUnread = { ...unread };
+      if (updatedUnread.channelSid === channelSid) {
+        updatedUnread.numberOfUnreads = numberOfUnreads;
+      }
+      return updatedUnread;
+    });
+  } else {
+    updatedUnreads = [...unreads];
+    const newUnread = {
+      channelSid,
+      numberOfUnreads,
+      relatedTo: user,
+    };
+    updatedUnreads.push(newUnread);
   }
+  post.set('attributes.unreads', updatedUnreads);
+  post.save(null, { useMasterKey: true });
 };
 
 /**
@@ -254,25 +245,20 @@ const createGeneralUnreadMessagesPost = async user => {
  *
  * @param {*} channelsid
  */
-const increasePostUnreadMessages = async (fromUser, channel) => {
+const increasePostUnreadMessages = async (fromUser, channelSid) => {
   // Get all unreadMessages posts for the channel
   const unreadMessagesPosts = await new Parse.Query('Post')
     .equalTo('type', UNREADMESSAGES_POST_TYPE)
-    .equalTo('attributes.channelSid', channel.sid)
+    .equalTo('attributes.unreads.channelSid', channelSid)
     .notEqualTo('author', fromUser)
     .find({ userMasterKey: true });
 
   // Increase by 1 the unreadMessages counter
   if (unreadMessagesPosts.length) {
     unreadMessagesPosts.forEach(urmp => {
-      db.getValueForNextSequence(`unreadMessages_${urmp.id}`)
-        .then(numberOfUnread => {
-          urmp.set(
-            'body',
-            `You have (${numberOfUnread}) unread message/s in the conversation: (${channel.FriendlyName}).`,
-          );
-          urmp.set('attributes.numberOfUnread', numberOfUnread);
-          urmp.save(null, { useMasterKey: true });
+      db.getValueForNextSequence(`unread_${urmp.id}_${channelSid}`)
+        .then(numberOfUnreads => {
+          updateUnreadMessagesPost(urmp, channelSid, numberOfUnreads, fromUser);
         })
         .catch(error => {
           throw new FeedServiceError(error.message);
@@ -282,97 +268,34 @@ const increasePostUnreadMessages = async (fromUser, channel) => {
 };
 
 /**
- * Retrieves all the post with type = GENERAL_UNREADMESSAGES_POST_TYPE
- * and increases the unreadMessages attribute
- *
- * @param {*} channelsid
- */
-const increaseGeneralPostUnreadMessages = async (users, channel) => {
-  users.forEach(user => {
-    new Parse.Query('Post')
-      .equalTo('type', GENERAL_UNREADMESSAGES_POST_TYPE)
-      .equalTo('author', user)
-      .first({ userMasterKey: true })
-      .then(post => {
-        db.getValueForNextSequence(`generalUnreadMessages_${post.id}`).then(
-          numberOfUnread => {
-            post.set(
-              'body',
-              `You have (${numberOfUnread}) unread message/s in the conversation: (${channel.FriendlyName}).`,
-            );
-            post.set('attributes.numberOfUnread', numberOfUnread);
-            post.save(null, { useMasterKey: true });
-          },
-        );
-      })
-      .catch(error => {
-        throw new FeedServiceError(error.message);
-      });
-  });
-};
-
-/**
  * Retrieves all the post with type = UNREADMESSAGES_POST_TYPE
  * and updates the unreadMessages attribute (increase or decrease)
  *
  * @param {*} reader
  * @param {*} channelsid
  */
-const decreasePostUnreadMessages = async (reader, channel) => {
+const decreasePostUnreadMessages = async (reader, channelSid) => {
   // Get all unreadMessages posts for the channel
   const urmp = await new Parse.Query('Post')
     .equalTo('type', UNREADMESSAGES_POST_TYPE)
-    .equalTo('attributes.channelSid', channel.sid)
+    .equalTo('attributes.unreads.channelSid', channelSid)
     .equalTo('author', reader)
     .first({ useMasterKey: true });
 
   // Decrease by 1 the unreadMessages counter
   if (urmp) {
-    db.getPreviousValueForSequence(`unreadMessages_${urmp.id}`)
-      .then(numberOfUnread => {
-        urmp.set(
-          'body',
-          `You have (${numberOfUnread}) unread message/s in the conversation: (${channel.FriendlyName}).`,
-        );
-        urmp.set('attributes.numberOfUnread', numberOfUnread);
-        urmp.save(null, { useMasterKey: true });
+    db.getPreviousValueForSequence(`unread_${urmp.id}_${channelSid}`)
+      .then(numberOfUnreads => {
+        updateUnreadMessagesPost(urmp, channelSid, numberOfUnreads, reader);
       })
       .catch(error => {
         throw new FeedServiceError(error.message);
       });
   } else {
     throw new FeedServiceError(
-      `[CODE] Unread messages post not found for the channel ${channel.sid}`,
+      `[CODE] Unread messages post not found for the channel ${channelSid}`,
     );
   }
-};
-
-/**
- * Retrieves all the post with type = UNREADMESSAGES_POST_TYPE
- * and updates the unreadMessages attribute (increase or decrease)
- *
- * @param {*} reader
- * @param {*} channelsid
- */
-const decreaseGeneralPostUnreadMessages = async (reader, channel) => {
-  // Get the generalUnreadMessages posts for the channel
-  const post = await new Parse.Query('Post')
-    .equalTo('type', GENERAL_UNREADMESSAGES_POST_TYPE)
-    .equalTo('author', reader)
-    .first({ useMasterKey: true });
-
-  db.getPreviousValueForSequence(`generalUnreadMessages_${post.id}`)
-    .then(numberOfUnread => {
-      post.set(
-        'body',
-        `You have (${numberOfUnread}) unread message/s in the conversation: (${channel.FriendlyName}).`,
-      );
-      post.set('attributes.numberOfUnread', numberOfUnread);
-      post.save(null, { useMasterKey: true });
-    })
-    .catch(error => {
-      throw new FeedServiceError(error.message);
-    });
 };
 
 const createComment = async data => {
@@ -410,11 +333,8 @@ export default {
   deleteFeedAndPosts,
   createFeedForUser,
   createUnreadMessagesPost,
-  createGeneralUnreadMessagesPost,
   increasePostUnreadMessages,
-  increaseGeneralPostUnreadMessages,
   decreasePostUnreadMessages,
-  decreaseGeneralPostUnreadMessages,
   createComment,
   getFeeds,
 };

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -227,7 +227,7 @@ const setActiveStatus = async user => {
 
   // Create the user Feed object and the related initial posts
   await FeedService.createFeedForUser(user);
-  await FeedService.createGeneralUnreadMessagesPost(user);
+  await FeedService.createUnreadMessagesPost(user);
 
   // At this point, if the user hasn't 'active' status, he/she is in the waitlist
   // So default chat channels won't be created for the user yet.


### PR DESCRIPTION
Remade the logic for the unreadMessages post (Closes #272)

- Removed all general posts which contained a general count of the unreads
- Remade almost all the logic behind the unread messages posts.
- One post will contain all the info of the unreads in the field 'attributes.unreads', which is an array of objects with this structure:
```
    {
        channelSid: XXX,
        unreads: XXX(integer),
        relatedTo: userPointer,
    }
```